### PR TITLE
change README dir style

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,27 @@ xiyouLinux图书借阅平台
 
 ## 整体架构说明
 
-config ----spring 放置spring的配置文件  
+```
+config ----spring <-放置spring的配置文件  
        | 
-       ----database 放置数据库的配置文件  
+       ----database <-放置数据库的配置文件  
 
- dao ----dbfactory dao接口的生产工厂  
+ dao ----dbfactory <-dao接口的生产工厂  
      |
-     ----dbimpl   数据库接口的实现类  
+     ----dbimpl   <-数据库接口的实现类  
      |
-     ----dbservice 数据库所提供的调用接口  
+     ----dbservice <-数据库所提供的调用接口  
 
-model ----存放Java Bean等数据模型  
+model ---- <-存放Java Bean等数据模型  
 
-web  ----存放控制器  
+web  ---- <-存放控制器  
 
-test ----存放测试类  
+test ---- <-存放测试类  
 
-upload ----存放上传的文件  
+upload ---- <-存放上传的文件  
 
-view ----存放jsp、html等文件  
-
+view ---- <-存放jsp、html等文件
+```
 ---
 
 还有css、js等目录不在这里说明。

--- a/README.md
+++ b/README.md
@@ -3,43 +3,25 @@ xiyouLinux图书借阅平台
 
 ## 整体架构说明
 
-### config目录
-- **spring**
-> 放置spring的配置文件
+config ----spring 放置spring的配置文件
+       | 
+       ----database     放置数据库的配置文件
 
-- **database**
-> 放置数据库的配置文件
+ dao ----dbfactory dao接口的生产工厂
+     |
+     ----dbimpl   数据库接口的实现类
+     |
+     ----dbservice 数据库所提供的调用接口
 
----
-### dao目录
-- **dbfactory**
-> dao接口的生产工厂
+model ----存放Java Bean等数据模型
 
-- **dbimpl**
-> 数据库接口的实现类
+web  ----存放控制器
 
-- **dbservice**
-> 数据库所提供的调用接口
+test ----存放测试类
 
----
-### model目录
-> 存放Java Bean等数据模型
+upload ----存放上传的文件
 
----
-### web目录
-> 存放控制器
-
----
-### test目录
-> 存放测试类
-
----
-### upload目录
-> 存放上传的文件
-
----
-### view
-> 存放jsp、html等文件
+view ----存放jsp、html等文件
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,25 +3,25 @@ xiyouLinux图书借阅平台
 
 ## 整体架构说明
 
-config ----spring 放置spring的配置文件
+config ----spring 放置spring的配置文件  
        | 
-       ----database     放置数据库的配置文件
+       ----database 放置数据库的配置文件  
 
- dao ----dbfactory dao接口的生产工厂
+ dao ----dbfactory dao接口的生产工厂  
      |
-     ----dbimpl   数据库接口的实现类
+     ----dbimpl   数据库接口的实现类  
      |
-     ----dbservice 数据库所提供的调用接口
+     ----dbservice 数据库所提供的调用接口  
 
-model ----存放Java Bean等数据模型
+model ----存放Java Bean等数据模型  
 
-web  ----存放控制器
+web  ----存放控制器  
 
-test ----存放测试类
+test ----存放测试类  
 
-upload ----存放上传的文件
+upload ----存放上传的文件  
 
-view ----存放jsp、html等文件
+view ----存放jsp、html等文件  
 
 ---
 


### PR DESCRIPTION
The old `README`'s dir introduction is not clear.
So I change the dir introduction style(not use *).

Signed-off-by: Jack Kang xiyoulinux.kangyijie@gmail.com